### PR TITLE
Hold table height with a spinner while paging the ELO table

### DIFF
--- a/app/components/ui/Table.tsx
+++ b/app/components/ui/Table.tsx
@@ -18,6 +18,7 @@ interface TableProps<TData> {
    setSorting?: OnChangeFn<SortingState>;
    pagination?: PaginationState;
    setPagination?: OnChangeFn<PaginationState>;
+   isLoading?: boolean;
 }
 
 export function Table<TData>({
@@ -28,7 +29,21 @@ export function Table<TData>({
    setPagination,
    sorting,
    setSorting,
+   isLoading = false,
 }: TableProps<TData>): React.ReactNode {
+   const tbodyRef = React.useRef<HTMLTableSectionElement>(null);
+   const [lastBodyHeight, setLastBodyHeight] = React.useState<number | null>(null);
+
+   // Remember the body height while rows are shown, so the loading
+   // placeholder can hold the same height and the table doesn't collapse
+   // to just the header and jump back when the next page arrives.
+   React.useLayoutEffect(() => {
+      if (data.length > 0 && tbodyRef.current) {
+         setLastBodyHeight(tbodyRef.current.getBoundingClientRect().height);
+      }
+   }, [data]);
+
+   const showPlaceholder = isLoading && data.length === 0;
    const table = useReactTable({
       data,
       columns,
@@ -68,21 +83,43 @@ export function Table<TData>({
                   </tr>
                ))}
             </thead>
-            <tbody>
-               {table.getRowModel().rows.map((row) => (
-                  <tr
-                     key={row.id}
-                     onClick={() => onRowClick?.(row.original)}
-                     className={onRowClick ? "is-clickable" : ""}
-                  >
-                     {row.getVisibleCells().map((cell) => (
-                        <td key={cell.id}>
-                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </td>
-                     ))}
+            {showPlaceholder ? (
+               <tbody>
+                  <tr>
+                     <td colSpan={columns.length} className="border-b-0 p-0">
+                        <div
+                           className="flex items-center justify-center"
+                           style={{
+                              height: lastBodyHeight ?? undefined,
+                              minHeight: 80,
+                           }}
+                        >
+                           <div
+                              className="aqua-spinner"
+                              role="status"
+                              aria-label="Loading"
+                           />
+                        </div>
+                     </td>
                   </tr>
-               ))}
-            </tbody>
+               </tbody>
+            ) : (
+               <tbody ref={tbodyRef}>
+                  {table.getRowModel().rows.map((row) => (
+                     <tr
+                        key={row.id}
+                        onClick={() => onRowClick?.(row.original)}
+                        className={onRowClick ? "is-clickable" : ""}
+                     >
+                        {row.getVisibleCells().map((cell) => (
+                           <td key={cell.id}>
+                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                           </td>
+                        ))}
+                     </tr>
+                  ))}
+               </tbody>
+            )}
          </table>
       </div>
    );

--- a/app/routes/elo.tsx
+++ b/app/routes/elo.tsx
@@ -22,10 +22,16 @@ export default function Leaderboard(): React.ReactNode {
       orderBy: sorting[0]?.id ?? "elo",
       orderDirection: sorting[0]?.desc === false ? "asc" : "desc",
    });
-   const numPages =
-      eloLeaderboard.data?.total == null
-         ? null
-         : Math.ceil(eloLeaderboard.data.total / pagination.pageSize);
+
+   // Remember the last known total so the pager doesn't disappear (and the
+   // page doesn't jump) while the next page is being fetched.
+   const [lastTotal, setLastTotal] = React.useState<number | null>(null);
+   const dataTotal = eloLeaderboard.data?.total;
+   if (dataTotal != null && dataTotal !== lastTotal) {
+      setLastTotal(dataTotal);
+   }
+   const total = dataTotal ?? lastTotal;
+   const numPages = total == null ? null : Math.ceil(total / pagination.pageSize);
 
    const columns: Array<ColumnDef<TeamEloWithName>> = [
       {
@@ -48,8 +54,9 @@ export default function Leaderboard(): React.ReactNode {
             setPagination={setPagination}
             sorting={sorting}
             setSorting={setSorting}
+            isLoading={eloLeaderboard.isFetching}
          />
-         {eloLeaderboard.data && numPages != null && (
+         {numPages != null && (
             <div className="flex justify-end items-baseline gap-4">
                <Button
                   onClick={() =>


### PR DESCRIPTION
When flipping pages the table body used to collapse to just the header and then jump back when the next page arrived. The Table now remembers its last body height and, while loading with no rows, renders a centered spinner at exactly that height. The ELO pager also keeps the last known page count so the prev/next buttons don't vanish mid-fetch.


Claude-Session: https://claude.ai/code/session_01MLpkHFwXWKuHJiUd1cWmin