### PR TITLE
Restore Corepack in Docker image for Node 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:26-alpine AS development-dependencies-env
-RUN corepack enable pnpm
+RUN npm install -g corepack && corepack enable pnpm
 COPY package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm install
 
 FROM node:26-alpine AS build-env
-RUN corepack enable pnpm
+RUN npm install -g corepack && corepack enable pnpm
 # Define build arguments
 ARG VITE_SUPABASE_URL
 ARG VITE_SUPABASE_ANON_KEY
@@ -18,7 +18,7 @@ WORKDIR /app
 RUN pnpm build
 
 FROM node:26-alpine
-RUN corepack enable pnpm
+RUN npm install -g corepack && corepack enable pnpm
 ENV NODE_ENV=production
 # Define build arguments again for the final stage
 ARG VITE_SUPABASE_URL


### PR DESCRIPTION
## Summary

The Fly deploy for #690 failed during the Docker build: Node 25+ no longer bundles Corepack, so `RUN corepack enable pnpm` fails with `corepack: not found` on `node:26-alpine`. (Fly kept serving the previous release; nothing shipped broken.)

## Changes

- Install Corepack from npm (`npm install -g corepack`) before `corepack enable pnpm` in all three Dockerfile stages. The pnpm version remains pinned solely by the `packageManager` field in package.json.

Failed run for reference: https://github.com/nino/ninoes/actions/runs/30090187047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WT1tU7aWv69o1aeFh2VGuy

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT1tU7aWv69o1aeFh2VGuy)_