### PR TITLE
Fix main: migrate to react-table v9, and stop red dependabot PRs from merging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,6 +10,14 @@ jobs:
       runs-on: ubuntu-latest
       if: ${{ github.actor == 'dependabot[bot]' }}
       steps:
+         # `--auto` only waits when the target branch has a required status
+         # check. Without one it merges at once, which is how react-table v9
+         # reached main with a red CI run. main requires the `checks` context
+         # from ci.yml — keep the two in sync, or this silently stops gating.
+         #
+         # A push made with GITHUB_TOKEN does not start `push` workflows, so
+         # nothing here runs CI or Fly Deploy on main after a merge. Deploys
+         # after Dependabot merges are run by hand.
          - name: Enable auto-merge for Dependabot PRs
            run: gh pr merge --auto --merge "$PR_URL"
            env:

--- a/app/NamesRanking.tsx
+++ b/app/NamesRanking.tsx
@@ -1,8 +1,7 @@
 import { useNames, useVotes } from "./hooks/useSupabase";
 import type { Name, VoteWithExtras } from "./model/types";
 import { type ReactNode } from "react";
-import { Table } from "~/components/ui/Table";
-import type { ColumnDef } from "@tanstack/react-table";
+import { Table, type TableColumnDef } from "~/components/ui/Table";
 import { Spinner } from "./components/ui/Spinner";
 
 export function NamesRanking(): ReactNode {
@@ -20,7 +19,7 @@ export function NamesRanking(): ReactNode {
       orderDirection: "desc",
    });
 
-   const nameColumns: Array<ColumnDef<Name>> = [
+   const nameColumns: Array<TableColumnDef<Name>> = [
       { accessorKey: "name", header: "Name" },
       {
          accessorKey: "created_at",
@@ -29,7 +28,7 @@ export function NamesRanking(): ReactNode {
       },
    ];
 
-   const voteColumns: Array<ColumnDef<VoteWithExtras>> = [
+   const voteColumns: Array<TableColumnDef<VoteWithExtras>> = [
       { accessorKey: "name.name", header: "Name" },
       { accessorKey: "user.name", header: "User ID" },
       { accessorKey: "vote_type", header: "Vote Type" },

--- a/app/components/ui/Table.test.tsx
+++ b/app/components/ui/Table.test.tsx
@@ -1,11 +1,10 @@
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { ColumnDef } from "@tanstack/react-table";
-import { Table } from "./Table";
+import { Table, type TableColumnDef } from "./Table";
 
 type Row = { name: string; elo: number };
 
-const columns: Array<ColumnDef<Row>> = [
+const columns: Array<TableColumnDef<Row>> = [
    { accessorKey: "elo", header: "ELO" },
    { accessorKey: "name", header: "Name" },
 ];

--- a/app/components/ui/Table.tsx
+++ b/app/components/ui/Table.tsx
@@ -1,19 +1,37 @@
 import {
    type ColumnDef,
+   columnVisibilityFeature,
+   createSortedRowModel,
    flexRender,
-   getCoreRowModel,
-   getSortedRowModel,
    type OnChangeFn,
    type PaginationState,
+   type RowData,
+   rowPaginationFeature,
+   rowSortingFeature,
    type SortingState,
-   useReactTable,
+   tableFeatures,
+   useTable,
 } from "@tanstack/react-table";
 import React from "react";
 import { Spinner } from "./Spinner";
 
-interface TableProps<TData> {
+// v9 needs every feature to be registered. These are the ones this table uses:
+// column visibility for getVisibleLeafColumns/getVisibleCells, sorting for the
+// clickable headers, and pagination for the externally held page state.
+const features = tableFeatures({
+   columnVisibilityFeature,
+   rowPaginationFeature,
+   rowSortingFeature,
+   sortedRowModel: createSortedRowModel(),
+});
+
+// v9 makes ColumnDef generic over the feature set. Call sites all use this
+// table, so they import this alias and don't name the features themselves.
+export type TableColumnDef<TData extends RowData> = ColumnDef<typeof features, TData>;
+
+interface TableProps<TData extends RowData> {
    data: Array<TData>;
-   columns: Array<ColumnDef<TData>>;
+   columns: Array<TableColumnDef<TData>>;
    onRowClick?: (row: TData) => void;
    sorting?: SortingState;
    setSorting?: OnChangeFn<SortingState>;
@@ -22,7 +40,7 @@ interface TableProps<TData> {
    isLoading?: boolean;
 }
 
-export function Table<TData>({
+export function Table<TData extends RowData>({
    data,
    columns,
    onRowClick,
@@ -57,11 +75,11 @@ export function Table<TData>({
          : pagination != null && pagination.pageSize !== lastRowCount
            ? (lastBodyHeight / lastRowCount) * pagination.pageSize
            : lastBodyHeight;
-   const table = useReactTable({
+   // The core row model is built automatically in v9, so it is no longer passed.
+   const table = useTable({
+      features,
       data,
       columns,
-      getCoreRowModel: getCoreRowModel(),
-      getSortedRowModel: getSortedRowModel(),
       onSortingChange: setSorting,
       onPaginationChange: setPagination,
       state: { sorting, pagination },

--- a/app/routes/elo.tsx
+++ b/app/routes/elo.tsx
@@ -2,8 +2,8 @@ import { useEloLeaderboard, useTeams } from "~/hooks/useSupabase";
 import { usePreviousValue } from "~/hooks/usePreviousValue";
 import React from "react";
 import type { TeamEloWithName } from "~/model/types";
-import { Table } from "~/components/ui/Table";
-import { type SortingState, type ColumnDef } from "@tanstack/react-table";
+import { Table, type TableColumnDef } from "~/components/ui/Table";
+import { type SortingState } from "@tanstack/react-table";
 import { Button } from "~/components/ui/Button";
 
 export default function Leaderboard(): React.ReactNode {
@@ -26,7 +26,7 @@ export default function Leaderboard(): React.ReactNode {
    const total = usePreviousValue(eloLeaderboard.data?.total);
    const numPages = total == null ? null : Math.ceil(total / pagination.pageSize);
 
-   const columns: Array<ColumnDef<TeamEloWithName>> = [
+   const columns: Array<TableColumnDef<TeamEloWithName>> = [
       { accessorKey: "elo", header: "ELO" },
       { accessorKey: "name.name", header: "Name" },
    ];

--- a/app/routes/leaderboard.tsx
+++ b/app/routes/leaderboard.tsx
@@ -1,8 +1,7 @@
 import { useNameScores } from "~/hooks/useSupabase";
 import type { NameScore } from "~/hooks/useSupabase";
 import { type ReactNode, useState } from "react";
-import { Table } from "~/components/ui/Table";
-import type { ColumnDef } from "@tanstack/react-table";
+import { Table, type TableColumnDef } from "~/components/ui/Table";
 
 export default function Leaderboard(): ReactNode {
    const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
@@ -15,7 +14,7 @@ export default function Leaderboard(): ReactNode {
       orderDirection: sorting[0]?.desc !== false ? "desc" : "asc",
    });
 
-   const columns: Array<ColumnDef<NameScore>> = [
+   const columns: Array<TableColumnDef<NameScore>> = [
       { accessorKey: "name", header: "Name" },
       {
          accessorKey: "score",

--- a/app/routes/teams.tsx
+++ b/app/routes/teams.tsx
@@ -17,9 +17,8 @@ import type { User } from "@supabase/supabase-js";
 import { requireUser } from "~/server/guards.server";
 import { Button } from "~/components/ui/Button";
 import { Input } from "~/components/ui/Input";
-import { Table } from "~/components/ui/Table";
+import { Table, type TableColumnDef } from "~/components/ui/Table";
 import { useToast } from "~/components/ui/Toast";
-import type { ColumnDef } from "@tanstack/react-table";
 import { Spinner } from "~/components/ui/Spinner";
 
 const createTeamSchema = z.object({ name: z.string().min(1, "Team name is required") });
@@ -60,7 +59,7 @@ export default function Teams(): React.ReactNode {
       resolver: zodResolver(joinTeamSchema),
    });
 
-   const columns: Array<ColumnDef<Team>> = [
+   const columns: Array<TableColumnDef<Team>> = [
       { accessorKey: "name", header: "Name" },
       {
          accessorKey: "created_at",
@@ -108,7 +107,7 @@ export default function Teams(): React.ReactNode {
       },
    ];
 
-   const membershipColumns: Array<ColumnDef<TeamMembershipWithTeam>> = [
+   const membershipColumns: Array<TableColumnDef<TeamMembershipWithTeam>> = [
       { accessorKey: "team.name", header: "Team Name" },
       {
          accessorKey: "team.created_at",

--- a/app/routes/votes.tsx
+++ b/app/routes/votes.tsx
@@ -1,11 +1,10 @@
 import { useDeleteVote, useVotes } from "~/hooks/useSupabase";
 import { type VoteWithExtras } from "~/model/types";
 import { type ReactNode } from "react";
-import { Table } from "~/components/ui/Table";
+import { Table, type TableColumnDef } from "~/components/ui/Table";
 import { Button } from "~/components/ui/Button";
 import { Spinner } from "~/components/ui/Spinner";
 import { useToast } from "~/components/ui/Toast";
-import type { ColumnDef } from "@tanstack/react-table";
 
 export default function Votes(): ReactNode {
    const { data: votesData, isFetching: isLoadingVotes } = useVotes({
@@ -31,7 +30,7 @@ export default function Votes(): ReactNode {
       }
    };
 
-   const voteColumns: Array<ColumnDef<VoteWithExtras>> = [
+   const voteColumns: Array<TableColumnDef<VoteWithExtras>> = [
       { accessorKey: "name.name", header: "Name" },
       { accessorKey: "user.name", header: "User ID" },
       { accessorKey: "vote_type", header: "Vote Type" },


### PR DESCRIPTION
## Why

`main` is broken. `pnpm typecheck`, `pnpm test` and `pnpm build` all fail on `c5aeff2`.

The cause is [#713](https://github.com/nino/ninoes/pull/713), which bumped `@tanstack/react-table` 8.21.3 → 9.0.0. Its CI run reported **FAILURE** and it merged anyway.

Five later dependabot PRs (#708, #711, #712, #707, #709) also show red, but they are collateral — they were rebased onto the already-broken `main`. Pinning react-table back to 8.21.3 turns all four checks green, which confirms it is the only real cause.

> The earlier red run on `main` from Aug 6 is unrelated: both CI and Fly Deploy died in *Set up job* with `Failed to resolve action download info. Error: Service Unavailable`. That was a GitHub Actions outage, not code.

## The migration

v9 removed the v8 entry points this table used:

| v8 | v9 |
| --- | --- |
| `useReactTable` | `useTable` |
| `getCoreRowModel()` | built automatically, no longer passed |
| `getSortedRowModel()` | `createSortedRowModel()` in the feature set |
| `ColumnDef<TData>` | `ColumnDef<TFeatures, TData>` |

Features are no longer implicit, so `Table.tsx` registers the three it actually uses: `columnVisibilityFeature` (for `getVisibleLeafColumns` / `getVisibleCells`), `rowSortingFeature` and `rowPaginationFeature`.

`ColumnDef` is now generic over the feature set. Rather than name features at all six call sites, `Table.tsx` exports a `TableColumnDef<TData>` alias bound to its own feature set:

```ts
export type TableColumnDef<TData extends RowData> = ColumnDef<typeof features, TData>;
```

Call sites just swap their `@tanstack/react-table` import for that alias, so the diff stays small and one file owns the feature set.

I did **not** use the `@tanstack/react-table/legacy` shim — it exists, but every symbol on it is already deprecated.

## Verification

`typecheck`, `lint`, `test` and `build` all pass. Beyond the existing suite I threw away a scratch test that checked behaviour the current tests do not cover, all passing:

- accessor values render into cells
- clicking a sortable header calls `setSorting`
- the sort indicator appears on the sorted column only
- rows sort client-side from `sorting` state
- `onRowClick` receives the original row

Happy to land that as a permanent test if you want it.

## Stopping the recurrence

`gh pr merge --auto` only queues behind a **required status check**. `main` had no branch protection, so `--auto` merged immediately and CI was never a gate.

**`main` now requires the `checks` context** (admins not enforced, so direct pushes still work; no review required, so Dependabot auto-merge still functions once green). That is a repo setting, not part of this diff — the workflow change here is **comments only**, recording the dependency so the gate is not removed by accident.

The second comment records a related quirk: a push authenticated with `GITHUB_TOKEN` does not start `push`-triggered workflows. That is why **neither CI nor Fly Deploy ran on `main` for any of the eight merges** on 2026-08-09 — the breakage never surfaced on `main`, and prod was never redeployed. Deploys after Dependabot merges are run by hand.

### Note

**Prod is stale, not broken** — it is still serving the last good build. Run Fly Deploy once this lands to ship the accumulated dependency bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)